### PR TITLE
fix: correct card hover detection after zoom operations

### DIFF
--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -2,7 +2,7 @@ import { Group, Rect, Text } from 'react-konva'
 import type { KonvaEventObject } from 'konva/lib/Node'
 import type { UserStory } from '../types/story'
 import { useStoryStore } from '../stores/storyStore'
-import { isPointerInsideCard } from '../utils/geometryUtils'
+import { isPointerInsideCardWithTransform } from '../utils/geometryUtils'
 
 interface StoryCardProps {
   story: UserStory
@@ -94,8 +94,21 @@ export const StoryCard = ({
         height: CARD_HEIGHT,
       }
 
+      // Get stage transformation info
+      const stageTransform = {
+        x: stage.x(),
+        y: stage.y(),
+        scaleX: stage.scaleX(),
+        scaleY: stage.scaleY(),
+      }
+
       if (
-        isPointerInsideCard(pointerPosition.x, pointerPosition.y, otherPosition)
+        isPointerInsideCardWithTransform(
+          pointerPosition.x,
+          pointerPosition.y,
+          otherPosition,
+          stageTransform
+        )
       ) {
         newHoveredStoryId = otherStory.id
         break // Only one card can be hovered at a time

--- a/src/utils/geometryUtils.ts
+++ b/src/utils/geometryUtils.ts
@@ -5,6 +5,13 @@ export interface BoundingBox {
   height: number
 }
 
+export interface StageTransform {
+  x: number
+  y: number
+  scaleX: number
+  scaleY: number
+}
+
 export const isPointerInsideCard = (
   pointerX: number,
   pointerY: number,
@@ -15,5 +22,23 @@ export const isPointerInsideCard = (
     pointerX <= targetCard.x + targetCard.width &&
     pointerY >= targetCard.y &&
     pointerY <= targetCard.y + targetCard.height
+  )
+}
+
+export const isPointerInsideCardWithTransform = (
+  stagePointerX: number,
+  stagePointerY: number,
+  targetCard: BoundingBox,
+  stageTransform: StageTransform
+): boolean => {
+  // Convert stage pointer coordinates to world coordinates
+  const worldX = (stagePointerX - stageTransform.x) / stageTransform.scaleX
+  const worldY = (stagePointerY - stageTransform.y) / stageTransform.scaleY
+
+  return (
+    worldX >= targetCard.x &&
+    worldX <= targetCard.x + targetCard.width &&
+    worldY >= targetCard.y &&
+    worldY <= targetCard.y + targetCard.height
   )
 }


### PR DESCRIPTION
## Summary

Fixes card hover detection during drag operations after zoom in/out operations.

## Changes

- Add `isPointerInsideCardWithTransform()` function to handle coordinate transformation when stage is scaled/translated
- Update StoryCard drag detection to use new transform-aware function
- Ensures proper conversion between stage coordinates and world coordinates

## Test Plan

- [x] All existing tests pass (unit tests, E2E tests)
- [x] Manual testing confirms hover detection works at different zoom levels
- [x] Pre-commit hooks pass (TypeScript, ESLint, Prettier)
- [x] Drag and drop functionality continues to work correctly

Fixes #12